### PR TITLE
Implement logic for Yodlee into the Assets microservice

### DIFF
--- a/assets/requirements.txt
+++ b/assets/requirements.txt
@@ -10,6 +10,7 @@ idna==3.2
 itsdangerous==2.0.1
 Jinja2==3.0.1
 MarkupSafe==2.0.1
+python-dotenv==0.19.0
 pytz==2021.1
 requests==2.26.0
 six==1.16.0

--- a/assets/src/blueprints/balances.py
+++ b/assets/src/blueprints/balances.py
@@ -1,6 +1,6 @@
 from flask import request, Blueprint
 from flask_restful import Resource, Api
-from utils import nordigen
+from utils import nordigen, yodlee
 
 
 balances = Blueprint('balances', __name__)
@@ -11,6 +11,7 @@ class GetBalances(Resource):
     def get(self):
         data = {
             'nordigen': nordigen.get_account_balances(request.headers.get('nordigen')),
+            'yodlee': yodlee.get_balances(request.headers.get('yodlee_loginName'))
         }
 
         return data

--- a/assets/src/blueprints/transactions.py
+++ b/assets/src/blueprints/transactions.py
@@ -1,6 +1,6 @@
 from flask import request, Blueprint
 from flask_restful import Resource, Api
-from utils import nordigen
+from utils import nordigen, yodlee
 
 transactions = Blueprint('transactions', __name__)
 api = Api(transactions)
@@ -9,7 +9,8 @@ api = Api(transactions)
 class GetTransactions(Resource):
     def get(self):
         data = {
-            'nordigen': nordigen.get_account_transactions(request.headers.get('nordigen'))
+            'nordigen': nordigen.get_account_transactions(request.headers.get('nordigen')),
+            'yodlee': yodlee.get_transactions(request.headers.get('yodlee_loginName'))
         }
 
         return data

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -39,6 +39,8 @@ def get_access_token(loginName):
         return 'An error occured'
 
 def get_balances(loginName):
+    if not loginName: return 'No loginName was provided'
+
     data = {}
     # try to obtain a token and return an error if it fails
     access_token = get_access_token(loginName)
@@ -58,6 +60,8 @@ def get_balances(loginName):
         return 'An error occured'
 
 def get_transactions(loginName):
+    if not loginName: return 'No loginName was provided'
+
     # try to obtain a token and return an error if it fails
     access_token = get_access_token(loginName)
     if access_token != 'An error occured':

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -24,7 +24,7 @@ import requests, os
 CLIENT_ID = os.environ.get('YODLEE_CLIENT_ID')
 SECRET = os.environ.get('YODLEE_SECRET')
 
-URL = "https://sandbox.api.yodlee.uk/ysl/"
+URL = os.environ.get('YODLEE_SANDBOX_URL')
 
 def get_access_token(loginName):
     # set up x-www-form-urlencoded data and header data for the request

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -30,49 +30,49 @@ def get_access_token(loginName):
     # set up x-www-form-urlencoded data and header data for the request
     data = {'clientId': CLIENT_ID, 'secret': SECRET}
     headers = {'Api-Version': '1.1', 'loginName': loginName}
+    # send the request and return the access token
+    response = requests.post(URL + 'auth/token', data=data, headers=headers)
     try:
-        # send the request and return the access token
-        response = requests.post(URL + 'auth/token', data=data, headers=headers)
         return response.json()['token']['accessToken']
     except:
         # return an error if it has occured
-        return 'An error occured'
+        return f"Error: {response.json()['errorCode']}; {response.json()['errorMessage']}"
 
 def get_balances(loginName):
-    if not loginName: return 'No loginName was provided'
+    if not loginName: return 'No Yodlee loginName was provided'
 
     data = {}
     # try to obtain a token and return an error if it fails
     access_token = get_access_token(loginName)
-    if access_token != 'An error occured':
+    if 'Error' not in access_token:
+        # set up header data for the request
+        headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token}
+        # send the request and save the balance for each account
+        response = requests.get(URL + 'accounts', headers=headers)
         try:
-            # set up header data for the request
-            headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token}
-            # send the request and save the balance for each account
-            response = requests.get(URL + 'accounts', headers=headers)
             for account in response.json()['account']:
                 data[account['accountName']] = account['balance']
             return data
         except:
             # return an error if it has occured
-            return 'An error occured'
+            return f"Error: {response.json()['errorCode']}; {response.json()['errorMessage']}"
     else:
-        return 'An error occured'
+        return access_token
 
 def get_transactions(loginName):
-    if not loginName: return 'No loginName was provided'
+    if not loginName: return 'No Yodlee loginName was provided'
 
     # try to obtain a token and return an error if it fails
     access_token = get_access_token(loginName)
-    if access_token != 'An error occured':
+    if 'Error' not in access_token:
+        # set up header data for the request
+        headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token}
+        # send the request and save the balance for each account
+        response = requests.get(URL + 'transactions', headers=headers)
         try:
-            # set up header data for the request
-            headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token}
-            # send the request and save the balance for each account
-            response = requests.get(URL + 'transactions', headers=headers)
             return response.json()
         except:
             # return an error if it has occured
-            return 'An error occured'
+            return f"Error: {response.json()['errorCode']}; {response.json()['errorMessage']}"
     else:
-        return 'An error occured'
+        return access_token

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -1,31 +1,49 @@
 import requests, os
 
 """
-    explain how the whole thing works
- """
+    HOW THIS WHOLE THING WORKS:
+    1. We need to obtain an access token
+        - in order to access information for an end user, every time we need that request we need to use an access token
+        - access tokens expire every 30 minutes
+        - in order to generate an access token we need to know the loginName for the user(it will be stored in the DB and passed in the header)
+        - in order to generate an access token we need to have developer CLIENT_ID and SECRET which are stored in a .env file
+    2. We get information for a user using the access token
+        - in order to get information for a user we need to use the access token, placing it in the header as follows: {'Authorization: Bearer someTokenGoesHere'}
+"""
 
 # get yodlee developer credentials from .env file
-CLIENT_ID = ''
-SECRET = ''
+CLIENT_ID = os.environ.get('YODLEE_CLIENT_ID')
+SECRET = os.environ.get('YODLEE_SECRET')
 
 URL = "https://sandbox.api.yodlee.uk/ysl/"
 
 def get_access_token(loginName):
+    # set up x-www-form-urlencoded data and header data for the request
     data = {'clientId': CLIENT_ID, 'secret': SECRET}
     headers = {'Api-Version': '1.1', 'loginName': loginName}
     try:
+        # send the request and return the access token
         response = requests.post(URL + 'auth/token', data=data, headers=headers)
         return response.json()['token']['accessToken']
     except:
-        return response.json()['errorMessage']
+        # return an error if it has occured
+        return 'An error occured'
 
 def get_balances(loginName):
     data = {}
-    try:
-        headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + get_access_token(loginName)}
-        response = requests.get(URL + 'accounts', headers=headers)
-        for account in response.json()['account']:
-            data[account['accountName']] = account['balance']
-        return data
-    except:
+    # try to obtain a token and return an error if it fails
+    access_token = get_access_token(loginName)
+    if access_token != 'An error occured':
+        try:
+            # set up header data for the request
+            headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token}
+            # send the request and save the balance for each account
+            response = requests.get(URL + 'accounts', headers=headers)
+            for account in response.json()['account']:
+                data[account['accountName']] = account['balance']
+            return data
+        except:
+            # return an error if it has occured
+            return 'An error occured'
+    else:
         return 'An error occured'

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -1,0 +1,17 @@
+import requests, os
+
+"""
+    explain how the whole thing works
+ """
+
+# get yodlee developer credentials from .env file
+CLIENT_ID = ''
+SECRET = ''
+
+URL = "https://sandbox.api.yodlee.uk/ysl/"
+
+def get_access_token(loginName):
+    data = {'clientId': CLIENT_ID, 'secret': SECRET}
+    headers = {'Api-Version': '1.1', 'loginName': loginName}
+    response = requests.post(URL + 'auth/token', data=data, headers=headers)
+    return response.json()['token']['accessToken']

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -13,5 +13,19 @@ URL = "https://sandbox.api.yodlee.uk/ysl/"
 def get_access_token(loginName):
     data = {'clientId': CLIENT_ID, 'secret': SECRET}
     headers = {'Api-Version': '1.1', 'loginName': loginName}
-    response = requests.post(URL + 'auth/token', data=data, headers=headers)
-    return response.json()['token']['accessToken']
+    try:
+        response = requests.post(URL + 'auth/token', data=data, headers=headers)
+        return response.json()['token']['accessToken']
+    except:
+        return response.json()['errorMessage']
+
+def get_balances(loginName):
+    data = {}
+    try:
+        headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + get_access_token(loginName)}
+        response = requests.get(URL + 'accounts', headers=headers)
+        for account in response.json()['account']:
+            data[account['accountName']] = account['balance']
+        return data
+    except:
+        return 'An error occured'

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -9,6 +9,15 @@ import requests, os
         - in order to generate an access token we need to have developer CLIENT_ID and SECRET which are stored in a .env file
     2. We get information for a user using the access token
         - in order to get information for a user we need to use the access token, placing it in the header as follows: {'Authorization: Bearer someTokenGoesHere'}
+
+    DEVELOPMENT v PRODUCTION:
+    - in development we're using the Sandbox version of Yodlee which means:
+        - we're using the sandbox URL
+        - we're using the sandbox CLIENT_ID and SECRET
+        - we're using the 5 sandbox loginName's that are provided and contain mock data(we can't create more)
+    - for production we'll need to use the production URL
+    - for production we'll need to use the production CLIENT_ID and SECRET
+    - for production we'll need to generate unique loginNames for each user and store them in the DB
 """
 
 # get yodlee developer credentials from .env file
@@ -42,6 +51,22 @@ def get_balances(loginName):
             for account in response.json()['account']:
                 data[account['accountName']] = account['balance']
             return data
+        except:
+            # return an error if it has occured
+            return 'An error occured'
+    else:
+        return 'An error occured'
+
+def get_transactions(loginName):
+    # try to obtain a token and return an error if it fails
+    access_token = get_access_token(loginName)
+    if access_token != 'An error occured':
+        try:
+            # set up header data for the request
+            headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token}
+            # send the request and save the balance for each account
+            response = requests.get(URL + 'transactions', headers=headers)
+            return response.json()
         except:
             # return an error if it has occured
             return 'An error occured'


### PR DESCRIPTION
closes #67 

This PR adds all of the logic the Assets microservice will use for know from the Yodlee API.

## There are some important things to note
- The whole workflow is kind of strange
   1. We need to obtain an access token
        - in order to access information for an end user, every time we want to make a request we need to use an access token
        - access tokens expire every 30 minutes
        - in order to generate an access token we need to know the `loginName` for the user(it will be stored in the DB and passed in the header)
        - in order to generate an access token we need to have developer `CLIENT_ID` and `SECRET` which are stored in a .env file
    2. We get information for a user using the access token
        - in order to get information for a user we need to use the access token, placing it in the header as follows: `{'Authorization: Bearer someTokenGoesHere'}`
- There will be some differences in production vs development
    - in development we're using the Sandbox version of Yodlee which means:
        - we're using the sandbox URL
        - we're using the sandbox `CLIENT_ID` and `SECRET`
        - we're using the 5 sandbox `loginName`'s that are provided and contain mock data(we can't create more)
           - the 5 users are: `sbMem614b0864e48oc1` ; `sbMem614b0864e48oc2` ; `sbMem614b0864e48oc3` ; `sbMem614b0864e48oc4` ; `sbMem614b0864e48oc5`
    - for production we'll need to use the production URL
    - for production we'll need to use the production `CLIENT_ID` and `SECRET`
    - for production we'll need to generate unique `loginName`'s for each user and store them in the DB
    
## Next steps
- add logic in the Account microservice for generating unique `loginName`'s upon account creation
- add logic to the UI microservice for linking new accounts for the user