### PR TITLE
Standardize response data from the Assets microservice

### DIFF
--- a/assets/src/blueprints/balances.py
+++ b/assets/src/blueprints/balances.py
@@ -10,10 +10,10 @@ api = Api(balances)
 class GetBalances(Resource):
     def get(self):
         data = {
-            'nordigen': nordigen.get_account_balances(request.headers.get('nordigen')),
+            'nordigen': nordigen.get_account_balances(request.headers.get('nordigen_key')),
             'yodlee': yodlee.get_balances(request.headers.get('yodlee_loginName')),
             'binance': binance_api.get_balances(request.headers.get('binance_key'), request.headers.get('binance_secret')),
-            'coinbase': coinbase_api.get_account_balances(request.headers.get('c_key'), request.headers.get('c_secret'))
+            'coinbase': coinbase_api.get_account_balances(request.headers.get('coinbase_key'), request.headers.get('coinbase_secret'))
         }
 
         return data

--- a/assets/src/blueprints/transactions.py
+++ b/assets/src/blueprints/transactions.py
@@ -10,9 +10,9 @@ api = Api(transactions)
 class GetTransactions(Resource):
     def get(self):
         data = {
-            'nordigen': nordigen.get_account_transactions(request.headers.get('nordigen')),
+            'nordigen': nordigen.get_account_transactions(request.headers.get('nordigen_key')),
             'yodlee': yodlee.get_transactions(request.headers.get('yodlee_loginName')),
-            'coinbase': coinbase_api.get_transactions(request.headers.get('c_key'), request.headers.get('c_secret'))
+            'coinbase': coinbase_api.get_transactions(request.headers.get('coinbase_key'), request.headers.get('coinbase_secret'))
         }
 
         return data

--- a/assets/utils/binance_api.py
+++ b/assets/utils/binance_api.py
@@ -5,10 +5,8 @@ def validate_api_key_and_api_secret(api_key, api_secret):
     if not api_key or not api_secret:
         # return false bool to say the validation failed and the error message
         return False, {'status': 'failed', 'content': 'Error: API key or API secret was not provided'}
-    try:
-        client = Spot(api_key, api_secret)
-    except:
-        return False, {'status': 'failed', 'content': 'Error: API key or API secret is invalid'}
+    
+    client = Spot(api_key, api_secret)
 
     # try to make a request and if it fails it means the api key or api secret is invalid
     try:
@@ -42,4 +40,4 @@ def get_balances(api_key, api_secret):
             # save crypto type with balance
             data[balance['asset']] = balance['free']
 
-    return {'status': 'failed', 'content': data}
+    return {'status': 'success', 'content': data}

--- a/assets/utils/binance_api.py
+++ b/assets/utils/binance_api.py
@@ -4,11 +4,11 @@ from binance.spot import Spot
 def validate_api_key_and_api_secret(api_key, api_secret):
     if not api_key or not api_secret:
         # return false bool to say the validation failed and the error message
-        return False, 'Error: API key or API secret was not provided'
+        return False, {'status': 'failed', 'content': 'Error: API key or API secret was not provided'}
     try:
         client = Spot(api_key, api_secret)
     except:
-        return False, 'Error: API key or API secret is invalid'
+        return False, {'status': 'failed', 'content': 'Error: API key or API secret is invalid'}
 
     # try to make a request and if it fails it means the api key or api secret is invalid
     try:
@@ -16,7 +16,7 @@ def validate_api_key_and_api_secret(api_key, api_secret):
 
     except:
         # return false bool to say the validation failed and the error message
-        return False, 'Error: API key or API secret is invalid'
+        return False, {'status': 'failed', 'content': 'Error: API key or API secret is invalid'}
 
     # return true bool with comma to make it tuple
     return True,
@@ -42,4 +42,4 @@ def get_balances(api_key, api_secret):
             # save crypto type with balance
             data[balance['asset']] = balance['free']
 
-    return data
+    return {'status': 'failed', 'content': data}

--- a/assets/utils/binance_api.py
+++ b/assets/utils/binance_api.py
@@ -4,9 +4,11 @@ from binance.spot import Spot
 def validate_api_key_and_api_secret(api_key, api_secret):
     if not api_key or not api_secret:
         # return false bool to say the validation failed and the error message
-        return False, 'Api key or api secret was not provided'
-
-    client = Spot(api_key, api_secret)
+        return False, 'Error: API key or API secret was not provided'
+    try:
+        client = Spot(api_key, api_secret)
+    except:
+        return False, 'Error: API key or API secret is invalid'
 
     # try to make a request and if it fails it means the api key or api secret is invalid
     try:
@@ -14,7 +16,7 @@ def validate_api_key_and_api_secret(api_key, api_secret):
 
     except:
         # return false bool to say the validation failed and the error message
-        return False, 'Api key or api secret is invalid'
+        return False, 'Error: API key or API secret is invalid'
 
     # return true bool with comma to make it tuple
     return True,

--- a/assets/utils/coinbase_api.py
+++ b/assets/utils/coinbase_api.py
@@ -19,8 +19,15 @@ def get_account_balances(api_key, api_secret):
 
 
 def get_transactions(api_key, api_secret):
-    client = Client(api_key, api_secret)
-    client_accounts = client.get_accounts()
+    try:
+        client = Client(api_key, api_secret)
+    except Exception as e:
+        return f"Error: {e}"
+    
+    try:
+        client_accounts = client.get_accounts()
+    except Exception as e:
+        return f"Error: {e.message}"
 
     data = []
     for each_wallet in client_accounts["data"]:

--- a/assets/utils/coinbase_api.py
+++ b/assets/utils/coinbase_api.py
@@ -5,34 +5,34 @@ def get_account_balances(api_key, api_secret):
     try:
         client = Client(api_key, api_secret)
     except Exception as e:
-        return f"Error: {e}"
+        return {'status': 'failed', 'content': f"Error: {e}"}
     
     try:
         client_accounts = client.get_accounts()
     except Exception as e:
-        return f"Error: {e.message}"
+        return {'status': 'failed', 'content': f"Error: {e.message}"}
     
     data = []
     for account in client_accounts["data"]:
         data.append({"balance": account["balance"].amount, "currency": account["balance"].currency})
-    return data
+    return {'status': 'success', 'content': data}
 
 
 def get_transactions(api_key, api_secret):
     try:
         client = Client(api_key, api_secret)
     except Exception as e:
-        return f"Error: {e}"
+        return {'status':'failed', 'content': f"Error: {e}"}
     
     try:
         client_accounts = client.get_accounts()
     except Exception as e:
-        return f"Error: {e.message}"
+        return {'status':'failed', 'content': f"Error: {e.message}"}
 
     data = []
     for each_wallet in client_accounts["data"]:
         wallet_id = each_wallet.id
         transactions = client.get_transactions(wallet_id)
         data.append(transactions)
-    return data
+    return {'status': 'success', 'content': data}
 

--- a/assets/utils/coinbase_api.py
+++ b/assets/utils/coinbase_api.py
@@ -2,8 +2,16 @@ from coinbase.wallet.client import Client
 
 
 def get_account_balances(api_key, api_secret):
-    client = Client(api_key, api_secret)
-    client_accounts = client.get_accounts()
+    try:
+        client = Client(api_key, api_secret)
+    except Exception as e:
+        return f"Error: {e}"
+    
+    try:
+        client_accounts = client.get_accounts()
+    except Exception as e:
+        return f"Error: {e.message}"
+    
     data = []
     for account in client_accounts["data"]:
         data.append({"balance": account["balance"].amount, "currency": account["balance"].currency})

--- a/assets/utils/nordigen.py
+++ b/assets/utils/nordigen.py
@@ -13,7 +13,7 @@ def validate_requisition(requisition_id):
     # Check if requisition exist
     if response.status_code != 200:
         # return response error message with false variable to say validation failed
-        return response.json(), False
+        return 'Error: Nordigen requisition key is invalid', False
 
     # return json response with true variable to say validation is success
     return response.json(), True

--- a/assets/utils/nordigen.py
+++ b/assets/utils/nordigen.py
@@ -6,7 +6,7 @@ headers = {'Authorization': 'Token 201ad808f1e2dd3136777f56db2568a08fbfc219'}
 def validate_requisition(requisition_id):
     if not requisition_id:
         # return error message with false variable to say validation failed
-        return {'message': 'Nordigen requisition key was not provided'}, False
+        return 'Error: Nordigen requisition key was not provided', False
 
     response = requests.get(f'https://ob.nordigen.com/api/requisitions/{requisition_id}/', headers=headers)
 
@@ -36,7 +36,7 @@ def get_bank_accounts(requisition_id):
 
     if not accounts:
         # if user don't have accounts returns message with false variable to say user don't have accounts
-        return {'message': 'No bank accounts'}, False
+        return 'Error: no bank accounts', False
 
     # return all user account with true variable to say that he has accounts
     return accounts, True

--- a/assets/utils/nordigen.py
+++ b/assets/utils/nordigen.py
@@ -6,17 +6,17 @@ headers = {'Authorization': 'Token 201ad808f1e2dd3136777f56db2568a08fbfc219'}
 def validate_requisition(requisition_id):
     if not requisition_id:
         # return error message with false variable to say validation failed
-        return 'Error: Nordigen requisition key was not provided', False
+        return {'status': 'failed', 'content': 'Error: Nordigen requisition key was not provided'}, False
 
     response = requests.get(f'https://ob.nordigen.com/api/requisitions/{requisition_id}/', headers=headers)
 
     # Check if requisition exist
     if response.status_code != 200:
         # return response error message with false variable to say validation failed
-        return 'Error: Nordigen requisition key is invalid', False
+        return {'status': 'failed', 'content': 'Error: Nordigen requisition key is invalid'}, False
 
     # return json response with true variable to say validation is success
-    return response.json(), True
+    return {'status': 'success', 'content': response.json()}, True
 
 
 def get_bank_accounts(requisition_id):
@@ -29,17 +29,17 @@ def get_bank_accounts(requisition_id):
         return requisition[0], False
 
     # if requisition is valid we take the requisition
-    requisition = requisition[0]
+    requisition = requisition[0]['content']
 
     # get user all accounts
     accounts = requisition.get('accounts')
 
     if not accounts:
         # if user don't have accounts returns message with false variable to say user don't have accounts
-        return 'Error: no bank accounts', False
+        return {'status': 'failed', 'content': 'Error: no bank accounts'}, False
 
     # return all user account with true variable to say that he has accounts
-    return accounts, True
+    return {'status': 'success', 'content': accounts}, True
 
 
 def get_account_balances(requisition_id):
@@ -52,7 +52,7 @@ def get_account_balances(requisition_id):
         return accounts[0]
 
     # if requisition is valid and user has bank accounts we take his accounts
-    accounts = accounts[0]
+    accounts = accounts[0]['content']
 
     data = {}
 
@@ -64,7 +64,7 @@ def get_account_balances(requisition_id):
         data[account] = response.json().get('balances')[0]
 
     # return saved data
-    return data
+    return {'status': 'success', 'content': data}
 
 
 def get_account_transactions(requisition_id):
@@ -77,7 +77,7 @@ def get_account_transactions(requisition_id):
         return accounts[0]
 
     # if requisition is valid and user has bank accounts we take his accounts
-    accounts = accounts[0]
+    accounts = accounts[0]['content']
 
     data = {}
     for account in accounts:
@@ -87,4 +87,4 @@ def get_account_transactions(requisition_id):
         data[account] = response.json().get('transactions').get('booked')
 
     # return saved data
-    return data
+    return {'status': 'success', 'content': data}

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -33,20 +33,20 @@ def get_access_token(loginName):
     # send the request and return the access token
     response = requests.post(URL + 'auth/token', data=data, headers=headers)
     try:
-        return response.json()['token']['accessToken']
+        return {'status': 'success', 'content': response.json()['token']['accessToken']}
     except:
         # return an error if it has occured
-        return f"Error: {response.json()['errorMessage']}"
+        return {'status': 'failed', 'content': f"Error: {response.json()['errorMessage']}"}
 
 def get_balances(loginName):
-    if not loginName: return 'Error: no Yodlee loginName was provided'
+    if not loginName: return {'status': 'failed', 'content':'Error: no Yodlee loginName was provided'}
 
     data = {}
     # try to obtain a token and return an error if it fails
     access_token = get_access_token(loginName)
-    if 'Error' not in access_token:
+    if access_token['status'] == 'success':
         # set up header data for the request
-        headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token}
+        headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token['content']}
         # send the request and save the balance for each account
         response = requests.get(URL + 'accounts', headers=headers)
         try:
@@ -55,24 +55,24 @@ def get_balances(loginName):
             return data
         except:
             # return an error if it has occured
-            return f"Error: {response.json()['errorMessage']}"
+            return {'status': 'failed', 'content': f"Error: {response.json()['errorMessage']}"}
     else:
         return access_token
 
 def get_transactions(loginName):
-    if not loginName: return 'No Yodlee loginName was provided'
+    if not loginName: return {'status': 'failed', 'content':'Error: no Yodlee loginName was provided'}
 
     # try to obtain a token and return an error if it fails
     access_token = get_access_token(loginName)
-    if 'Error' not in access_token:
+    if access_token['status'] == 'success':
         # set up header data for the request
-        headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token}
+        headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token['content']}
         # send the request and save the balance for each account
         response = requests.get(URL + 'transactions', headers=headers)
         try:
             return response.json()
         except:
             # return an error if it has occured
-            return f"Error: {response.json()['errorMessage']}"
+            return {'status': 'failed', 'content': f"Error: {response.json()['errorMessage']}"}
     else:
         return access_token

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -52,7 +52,7 @@ def get_balances(loginName):
         try:
             for account in response.json()['account']:
                 data[account['accountName']] = account['balance']
-            return data
+            return {'status': 'success', 'content': data}
         except:
             # return an error if it has occured
             return {'status': 'failed', 'content': f"Error: {response.json()['errorMessage']}"}

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -36,7 +36,7 @@ def get_access_token(loginName):
         return response.json()['token']['accessToken']
     except:
         # return an error if it has occured
-        return f"Error: {response.json()['errorCode']}; {response.json()['errorMessage']}"
+        return f"Error: {response.json()['errorMessage']}"
 
 def get_balances(loginName):
     if not loginName: return 'Error: no Yodlee loginName was provided'
@@ -55,7 +55,7 @@ def get_balances(loginName):
             return data
         except:
             # return an error if it has occured
-            return f"Error: {response.json()['errorCode']}; {response.json()['errorMessage']}"
+            return f"Error: {response.json()['errorMessage']}"
     else:
         return access_token
 
@@ -73,6 +73,6 @@ def get_transactions(loginName):
             return response.json()
         except:
             # return an error if it has occured
-            return f"Error: {response.json()['errorCode']}; {response.json()['errorMessage']}"
+            return f"Error: {response.json()['errorMessage']}"
     else:
         return access_token

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -70,7 +70,7 @@ def get_transactions(loginName):
         # send the request and save the balance for each account
         response = requests.get(URL + 'transactions', headers=headers)
         try:
-            return response.json()
+            return {'status': 'success', 'content': response.json()}
         except:
             # return an error if it has occured
             return {'status': 'failed', 'content': f"Error: {response.json()['errorMessage']}"}

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -30,6 +30,7 @@ def get_access_token(loginName):
     # set up x-www-form-urlencoded data and header data for the request
     data = {'clientId': CLIENT_ID, 'secret': SECRET}
     headers = {'Api-Version': '1.1', 'loginName': loginName}
+
     # send the request and return the access token
     response = requests.post(URL + 'auth/token', data=data, headers=headers)
     try:
@@ -47,11 +48,13 @@ def get_balances(loginName):
     if access_token['status'] == 'success':
         # set up header data for the request
         headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token['content']}
+
         # send the request and save the balance for each account
         response = requests.get(URL + 'accounts', headers=headers)
         try:
             for account in response.json()['account']:
-                data[account['accountName']] = account['balance']
+                data[account['id']] = {"providerName": account["providerName"], "balanceData": account["balance"]}
+
             return {'status': 'success', 'content': data}
         except:
             # return an error if it has occured
@@ -67,6 +70,7 @@ def get_transactions(loginName):
     if access_token['status'] == 'success':
         # set up header data for the request
         headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token['content']}
+        
         # send the request and save the balance for each account
         response = requests.get(URL + 'transactions', headers=headers)
         try:

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -39,7 +39,7 @@ def get_access_token(loginName):
         return f"Error: {response.json()['errorCode']}; {response.json()['errorMessage']}"
 
 def get_balances(loginName):
-    if not loginName: return 'No Yodlee loginName was provided'
+    if not loginName: return 'Error: no Yodlee loginName was provided'
 
     data = {}
     # try to obtain a token and return an error if it fails


### PR DESCRIPTION
### Some of the changes only apply for Nordigen and Yodlee. Responses for Binance and Coinbase may be different since they're crypto-related and contain different data

This PR aims to standardize the response data from each provider in the Assets microservice. The responses will now come in the following format:
- for balances:
```JSON
{
    "provider1": {
        "status": "failed",
        "content": "Error: some error",
    },
    "provider2": {
        "status": "success",
        "content": {
            "someId": {
                "providerName": "SomeProvider",
                "balanceData": {
                    "currency": "USD",
                    "amount": 123123,
                }
            }
         }
    }
}
```
- for transactions:
```JSON
{
    "provider1": {
        "status": "failed",
        "content": "Error: some error",
    },
    "provider2": {
        "status": "success",
        "content": {
            "someProviderName": {
                "someTransactionId": {
                    "currency": "USD",
                    "amount": 123123,
                }
            }
         }
    }
}
```

#83 