### PR TITLE
Extend response formatting in Assets & add holdings endpoint for Yodlee, Coinbase and Binance

### DIFF
--- a/assets/src/app.py
+++ b/assets/src/app.py
@@ -2,8 +2,10 @@ from flask import Flask
 
 from src.blueprints.balances import balances
 from src.blueprints.transactions import transactions
+from src.blueprints.holdings import holdings
 
 app = Flask(__name__)
 
 app.register_blueprint(balances, url_prefix='/balances')
 app.register_blueprint(transactions, url_prefix='/transactions')
+app.register_blueprint(holdings, url_prefix='/holdings')

--- a/assets/src/blueprints/balances.py
+++ b/assets/src/blueprints/balances.py
@@ -12,8 +12,6 @@ class GetBalances(Resource):
         data = {
             'nordigen': nordigen.get_account_balances(request.headers.get('nordigen_key')),
             'yodlee': yodlee.get_balances(request.headers.get('yodlee_loginName')),
-            'binance': binance_api.get_balances(request.headers.get('binance_key'), request.headers.get('binance_secret')),
-            'coinbase': coinbase_api.get_account_balances(request.headers.get('coinbase_key'), request.headers.get('coinbase_secret'))
         }
 
         return data

--- a/assets/src/blueprints/holdings.py
+++ b/assets/src/blueprints/holdings.py
@@ -3,5 +3,20 @@ from flask_restful import Resource, Api
 from utils import binance_api, yodlee, coinbase_api
 
 
-holdings = Blueprint('transactions', __name__)
+holdings = Blueprint('holdings', __name__)
 api = Api(holdings)
+
+
+class GetHoldings(Resource):
+    def get(self):
+        data = {
+            'yodlee': yodlee.get_holdings(request.headers.get('yodlee_loginName')),
+            'binance': binance_api.get_balances(request.headers.get('binance_key'), request.headers.get('binance_secret')),
+            'coinbase': coinbase_api.get_account_balances(request.headers.get('coinbase_key'), request.headers.get('coinbase_secret'))
+        }
+
+        return data
+
+
+api.add_resource(GetHoldings, '/')
+ 

--- a/assets/src/blueprints/holdings.py
+++ b/assets/src/blueprints/holdings.py
@@ -1,0 +1,7 @@
+from flask import request, Blueprint
+from flask_restful import Resource, Api
+from utils import binance_api, yodlee, coinbase_api
+
+
+holdings = Blueprint('transactions', __name__)
+api = Api(holdings)

--- a/assets/utils/binance_api.py
+++ b/assets/utils/binance_api.py
@@ -1,4 +1,5 @@
 from binance.spot import Spot
+import uuid
 
 
 def validate_api_key_and_api_secret(api_key, api_secret):
@@ -35,9 +36,10 @@ def get_balances(api_key, api_secret):
     data = {}
 
     for balance in balances:
+        id = uuid.uuid4().int
         # check where the current user balance is more than 0
         if float(balance['free']) > 0:
             # save crypto type with balance
-            data[balance['asset']] = balance['free']
+            data[id] = {"symbol": balance["asset"], "quantity": balance['free']}
 
     return {'status': 'success', 'content': data}

--- a/assets/utils/coinbase_api.py
+++ b/assets/utils/coinbase_api.py
@@ -30,10 +30,19 @@ def get_transactions(api_key, api_secret):
     except Exception as e:
         return {'status':'failed', 'content': f"Error: {e.message}"}
 
-    data = []
-    for each_wallet in client_accounts["data"]:
-        wallet_id = each_wallet.id
-        transactions = client.get_transactions(wallet_id)
-        data.append(transactions)
+    data = {}
+    for wallet in client_accounts["data"]:
+        transactions = client.get_transactions(wallet.id, limit=10)
+
+        # check if there are any transactions for this wallet
+        if transactions["data"]:
+            transaction_data = {}
+            for transaction in transactions["data"]:
+                # return only the completed transactions
+                if transaction["status"] == "completed":
+                    transaction_data[transaction["id"]] = transaction['amount']
+            
+            data[wallet.name] = transaction_data
+
     return {'status': 'success', 'content': data}
 

--- a/assets/utils/coinbase_api.py
+++ b/assets/utils/coinbase_api.py
@@ -13,9 +13,12 @@ def get_account_balances(api_key, api_secret):
         return {'status': 'failed', 'content': f"Error: {e.message}"}
     
     data = {}
-    for account in client_accounts["data"]:
-        if float(account["balance"].amount) > 0:
-            data[account["id"]] = ({"symbol": account["balance"].currency, "quantity": account["balance"].amount, "value": account["native_balance"]})
+    try:
+        for account in client_accounts["data"]:
+            if float(account["balance"].amount) > 0:
+                data[account["id"]] = ({"symbol": account["balance"].currency, "quantity": account["balance"].amount, "value": account["native_balance"]})
+    except:
+        return {'status': 'failed', 'content': f"Error: unknown error"}
     return {'status': 'success', 'content': data}
 
 
@@ -31,18 +34,21 @@ def get_transactions(api_key, api_secret):
         return {'status':'failed', 'content': f"Error: {e.message}"}
 
     data = {}
-    for wallet in client_accounts["data"]:
-        transactions = client.get_transactions(wallet.id, limit=10)
+    try:
+        for wallet in client_accounts["data"]:
+            transactions = client.get_transactions(wallet.id, limit=10)
 
-        # check if there are any transactions for this wallet
-        if transactions["data"]:
-            transaction_data = {}
-            for transaction in transactions["data"]:
-                # return only the completed transactions
-                if transaction["status"] == "completed":
-                    transaction_data[transaction["id"]] = transaction['amount']
-            
-            data[wallet.name] = transaction_data
+            # check if there are any transactions for this wallet
+            if transactions["data"]:
+                transaction_data = {}
+                for transaction in transactions["data"]:
+                    # return only the completed transactions
+                    if transaction["status"] == "completed":
+                        transaction_data[transaction["id"]] = transaction['amount']
+                
+                data[wallet.name] = transaction_data
+    except:
+        return {'status': 'failed', 'content': f"Error: unknown error"}
 
     return {'status': 'success', 'content': data}
 

--- a/assets/utils/coinbase_api.py
+++ b/assets/utils/coinbase_api.py
@@ -12,9 +12,10 @@ def get_account_balances(api_key, api_secret):
     except Exception as e:
         return {'status': 'failed', 'content': f"Error: {e.message}"}
     
-    data = []
+    data = {}
     for account in client_accounts["data"]:
-        data.append({"balance": account["balance"].amount, "currency": account["balance"].currency})
+        if float(account["balance"].amount) > 0:
+            data[account["id"]] = ({"symbol": account["balance"].currency, "quantity": account["balance"].amount, "value": account["native_balance"]})
     return {'status': 'success', 'content': data}
 
 

--- a/assets/utils/nordigen.py
+++ b/assets/utils/nordigen.py
@@ -95,8 +95,8 @@ def get_account_transactions(requisition_id):
     accounts = accounts[0]['content']
 
     data = {}
-    transaction_data = {}
     for account in accounts:
+        transaction_data = {}   
         # get the name of the bank that the account belongs to
         bank_name = get_bank_name(account)
 

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -68,12 +68,29 @@ def get_transactions(loginName):
     # try to obtain a token and return an error if it fails
     access_token = get_access_token(loginName)
     if access_token['status'] == 'success':
-        # set up header data for the request
+        # set up header data and query parameters for the request
         headers = {'Api-Version': '1.1', 'Authorization': 'Bearer ' + access_token['content']}
+        params = {'top': 10}
         
         # send the request and save the balance for each account
-        response = requests.get(URL + 'transactions', headers=headers)
+        response = requests.get(URL + 'transactions', headers=headers, params=params)
         try:
+            try:
+                transactions = response.json()['transaction']
+            except:
+                return {'status': 'failed', 'content': "Error: no transactions found"}
+            data = {}
+
+            for transaction in transactions:
+                # check if other transactions for this merchant are already in the data object
+                transaction_parent = data.get(transaction['merchant']['name'], {})
+                transaction_data = {}
+
+                # add only the completed transactions
+                if transaction['status'] == 'POSTED':
+                    transaction_data[transaction['id']] = transaction['price']
+                    data[transaction_parent] += transaction_data
+
             return {'status': 'success', 'content': response.json()}
         except:
             # return an error if it has occured

--- a/assets/utils/yodlee.py
+++ b/assets/utils/yodlee.py
@@ -94,8 +94,10 @@ def get_holdings(loginName):
         # send the request and save the balance for each account
         response = requests.get(URL + 'holdings', headers=headers)
         try:
+            if not response.json().get('holding'):
+                return {'status': 'failed', 'content': "Error: no holdings found"}
             for holding in response.json()['holding']:
-                data[holding['symbol']] = {'quantity': holding['quantity'], 'value': holding['value']}
+                data[holding['id']] = {'symbol': holding['symbol'], 'quantity': holding['quantity'], 'value': holding['value']}
             return {'status': 'success', 'content': data}
         except:
             # return an error if it has occured

--- a/portfolio/portfolio/blueprints/api.py
+++ b/portfolio/portfolio/blueprints/api.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, request
 from flask_cors import CORS
-from ..utils.assets import get_balances, get_transactions
+from ..utils.assets import get_balances, get_transactions, get_holdings
 from ..utils.account import validate_auth_header
 
 bp = Blueprint('api', __name__)
@@ -18,7 +18,7 @@ def get_assets_balances():
     user_data = validated_token[1]
 
     # get balances data(done via Assets)
-    headers = {'yodlee_loginName':user_data[0]['yodlee_login_name'], 'binance_key':user_data[0]['binance_key'], 'binance_secret':user_data[0]['binance_secret']}
+    headers = {'yodlee_loginName':user_data[0]['yodlee_login_name'], 'nordigen_key': user_data[0]['nordigen_requisition']}
     response = jsonify(get_balances(headers))
     return response, 200
 
@@ -35,6 +35,23 @@ def get_assets_transactions():
     user_data = validated_token[1]
     
     # get transactions data(done via Assets)
-    headers = {'yodlee_loginName':user_data[0]['yodlee_login_name'], 'binance_key':user_data[0]['binance_key'], 'binance_secret':user_data[0]['binance_secret']}
+    headers = {'yodlee_loginName':user_data[0]['yodlee_login_name'], 'nordigen_key': user_data[0]['nordigen_requisition'],'binance_key':user_data[0]['binance_key'], 'binance_secret':user_data[0]['binance_secret'], 'coinbase_key': user_data[0]['coinbase_api_key'], 'coinbase_secret': user_data[0]['coinbase_api_secret']}
     response = jsonify(get_transactions(headers))
+    return response, 200
+
+
+@bp.route('/api/holdings', methods=(['GET']))
+def get_assets_holdings():
+    # check if a token was passed in the Authorization header
+    received_token = request.headers.get('Authorization')
+    validated_token = validate_auth_header(received_token)
+
+    if not validated_token[0]:
+        return jsonify(validated_token[1]), 401
+    
+    user_data = validated_token[1]
+    
+    # get holdings data(done via Assets)
+    headers = {'yodlee_loginName':user_data[0]['yodlee_login_name'], 'binance_key':user_data[0]['binance_key'], 'binance_secret':user_data[0]['binance_secret'], 'coinbase_key': user_data[0]['coinbase_api_key'], 'coinbase_secret': user_data[0]['coinbase_api_secret']}
+    response = jsonify(get_holdings(headers))
     return response, 200

--- a/portfolio/portfolio/utils/assets.py
+++ b/portfolio/portfolio/utils/assets.py
@@ -12,3 +12,8 @@ def get_balances(headers):
 def get_transactions(headers):
     res = requests.get(URL + "transactions/", headers=headers)
     return res.json()
+
+# fetch all holdings using Assets
+def get_holdings(headers):
+    res = requests.get(URL + "holdings/", headers=headers)
+    return res.json()


### PR DESCRIPTION
This PR extends the formatting from #101 and adds standardization for the newly-made `/holdings` endpoint which includes Yodlee, Binance and Coinbase, as well as standardization of the transactions output of Coinbase and Yodlee

The holdings output format:
```JSON
"providerName": {
        "status": "success",
        "content": {
            "xxxxxxx-xxxx-xxxx": {
                "symbol": "SYMBOL",
                "quantity": "9800.00000000",
                "value": {
                    "amount": "1801.24",
                    "currency": "GBP"
                }
            }
        }
    }
```

#### Note: The `value` part of the response is currently present in the Yodlee and Coinbase APIs. Further integration with the Reference microservice will allow for the `value` object to be added for the Binance and Custom Assets APIs(to be done in Portfolio)